### PR TITLE
Need to first check if there is an error before calling any answer fu…

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,6 +335,11 @@ MediaSession.prototype = extend(MediaSession.prototype, {
 
         var errorMsg = 'adding new stream';
         queueOfferAnswer(this, errorMsg, self.pc.remoteDescription, function(err, answer) {
+          if (err) {
+            self._log('error', 'Could not create offer for ' + errorMsg);
+            return cb(err);
+          }
+
           answer.jingle.contents.forEach(function (content) {
             filterContentSources(content, stream);
           });
@@ -405,6 +410,11 @@ MediaSession.prototype = extend(MediaSession.prototype, {
 
         var errorMsg = 'switching streams';
         queueOfferAnswer(self, errorMsg, this.pc.remoteDescription, function(err, answer) {
+          if (err) {
+            self._log('error', 'Could not create offer for ' + errorMsg);
+            return cb(err);
+          }
+
           answer.jingle.contents.forEach(function (content) {
             delete content.transport;
             delete content.application.payloads;


### PR DESCRIPTION
An error can occur when a real error is passed through the queueOfferAnswer function. If this happens, when the queue callback is called, the answer arg will be undefined. Some functions that call the queueOfferAnswer have follow up logic.

If this happens, answer could be called first and could be undefined, causing other issues.