### PR TITLE
Firefox fixes: Remove then add

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ function changeSendersIfNoMsids(content) {
 // filters the sources in baseContent to only include sources which don't have an msid (recvonly) and have a corresponding source in compareContent that has an msid
 // also returns a boolean indicating that there are sources
 function filterToMatchingRecvonly(baseContent, compareContent) {
-    // if the content is not rtp or if the senders (direction) hasn't changed, then ignore it
-    if (baseContent.application.applicationType !== 'rtp' || baseContent.senders === compareContent.senders) {
+    // if the content is not rtp, ignore it
+    if (baseContent.application.applicationType !== 'rtp') {
         return;
     }
 


### PR DESCRIPTION
Some changes to improve stability of firefox:
* On addStream, if there was a recvonly ssrc without an msid (like in Firefox) send a source-remove and then a source add.
* On removeStream, if there the new description has a recvonly ssrc without a msid then send a source-remove and then a source-add
* If the SDP is recvonly, change senders to both in the session-accept since this won't be changed later