### PR TITLE
Signal new recvonly ssrcs

### DIFF
--- a/index.js
+++ b/index.js
@@ -762,8 +762,11 @@ MediaSession.prototype = extend(MediaSession.prototype, {
         var errorMsg = 'adding new stream source';
         var oldLocalDescription = self.pc.localDescription;
         queueOfferAnswer(self, errorMsg, newDesc, function(err, answer) {
+            if (err) {
+                return cb({condition: 'general-error'})
+            }
             self._addRecvOnlySourceIfNotPresent(oldLocalDescription, answer.jingle);
-            return err ? cb({condition: 'general-error'}) : cb();
+            return cb();
         });
     },
 
@@ -833,8 +836,11 @@ MediaSession.prototype = extend(MediaSession.prototype, {
         var errorMsg = 'removing stream source';
         var oldLocalDescription = self.pc.localDescription;
         queueOfferAnswer(this, errorMsg, newDesc, function(err, answer) {
+            if (err) {
+                return cb({condition: 'general-error'})
+            }
             self._removeRecvOnlySourceIfPresent(oldLocalDescription, answer.jingle);
-            return err ? cb({condition: 'general-error'}) : cb();
+            return cb();
         });
     },
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function findMatchingContentBlock(content, jingleDescription) {
         return content.name === compareContent.name;
     });
     // intentionally returns null if more than one is matched as that shouldn't normally happen
-    if (matchingContents.length >= 1) {
+    if (matchingContents.length === 1) {
         return matchingContents[0];
     }
     return null;

--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ function findMatchingContentBlock(content, jingleDescription) {
     return null;
 }
 
-function findMatchingSource(baseSource, compareSources = []) {
+function findMatchingSource(baseSource, compareSources) {
+    compareSources = compareSources || [];
     for (var i = 0; i < compareSources.length; i++) {
         const compareSource = compareSources[i];
         if (baseSource.ssrc === compareSource.ssrc) {


### PR DESCRIPTION
In Firefox when a remote user adds a stream, Firefox will add an ssrc to its local sdp if needed so it can send RTCP feedback about that stream. This PR makes jingle-media-session send a source-add or source-remove when those recvonly ssrcs are added or removed when renegotiating the peer connection because of a remote stream being added/removed.