### PR TITLE
Set sdp-semantics if passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,9 +172,12 @@ function changeSendersIfNoMsids(content) {
 function MediaSession(opts) {
     BaseSession.call(this, opts);
 
+    var sdpSemantics = opts.parent && opts.parent.config && opts.parent.config.sdpSemantics;
+
     this.pc = new RTCPeerConnection({
         iceServers: opts.iceServers || [],
-        useJingle: true
+        useJingle: true,
+        sdpSemantics
     }, opts.constraints || {});
 
     this.q = queue({

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function MediaSession(opts) {
     this.pc = new RTCPeerConnection({
         iceServers: opts.iceServers || [],
         useJingle: true,
-        sdpSemantics
+        sdpSemantics: sdpSemantics
     }, opts.constraints || {});
 
     this.q = queue({


### PR DESCRIPTION
As Chrome is rolling out unified plan support in Chrome 72 we need the ability to choose which sdpSemantics to use